### PR TITLE
change option name from ocd to extra

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -31,10 +31,10 @@ After
 
 ## Options
 
-### ocd
+### extra
 
 ```js
-pretty(STRING_OF_HTML, {ocd: true});
+pretty(STRING_OF_HTML, {extra: true});
 ```
 
 **Type**: `Boolean`

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ After
 
 ## Options
 
-### ocd
+### extra
 
 ```js
-pretty(STRING_OF_HTML, {ocd: true});
+pretty(STRING_OF_HTML, {extra: true});
 ```
 
 **Type**: `Boolean`

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const defaults = {
   sep: '\n'
 };
 
-const ocd = (str, options) => {
+const extra = (str, options) => {
   // Normalize and condense all newlines
   return condense(str, options)
     // Remove empty whitespace the top of a file.
@@ -35,7 +35,7 @@ const pretty = (str, options = {}) => {
   var opts = { ...defaults, ...options };
   str = beautify.html(str, opts);
 
-  if (opts.ocd) {
+  if (opts.extra) {
     if (opts.newlines) opts.sep = opts.newlines;
     return ocd(str, opts);
   }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const pretty = (str, options = {}) => {
 
   if (opts.extra) {
     if (opts.newlines) opts.sep = opts.newlines;
-    return ocd(str, opts);
+    return extra(str, opts);
   }
 
   return str;

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ describe('pretty', () => {
       '  <body> this is content... </body>',
       '</html>',
     ].join('\n');
-    assert.equal(pretty(fixture, {ocd: true}), expected);
+    assert.equal(pretty(fixture, {extra: true}), expected);
   });
 
   it('should add a newline before comments', () => {
@@ -52,7 +52,7 @@ describe('pretty', () => {
       '  <body> this is content... </body>',
       '</html>',
     ].join('\n');
-    assert.equal(pretty(fixture, {ocd: true}), expected);
+    assert.equal(pretty(fixture, {extra: true}), expected);
   });
 
   it('should move "closing" comments after closing tags', () => {
@@ -79,7 +79,7 @@ describe('pretty', () => {
       '  <div> foo </div> <!-- /end -->',
       '</html>',
     ].join('\n');
-    assert.equal(pretty(fixture, {ocd: true}), expected);
+    assert.equal(pretty(fixture, {extra: true}), expected);
   });
 });
 


### PR DESCRIPTION
using ocd as an option name to turn on extra rules around whitespace etc is not very inclusive